### PR TITLE
Remove the attr_accessor around :tag.  No necessary, and causes problems...

### DIFF
--- a/_ext/tagger_sanitizer.rb
+++ b/_ext/tagger_sanitizer.rb
@@ -19,10 +19,9 @@ module Awestruct
       end
 
       module TagLinker
-        attr_accessor :tags
         def tag_links(delimiter = ', ', style_class = nil)
           class_attr = (style_class ? ' class="' + style_class + '"' : '')
-          tags.map{|tag| %Q{<a#{class_attr} href="#{tag.primary_page.url}">#{tag}</a>}}.join(delimiter)
+          self.tags.map{|tag| %Q{<a#{class_attr} href="#{tag.primary_page.url}">#{tag}</a>}}.join(delimiter)
         end
       end
 


### PR DESCRIPTION
Along with improvements on awestructx to add .erb support back, this change should allow your blog to generate.

Additionally, these changes have been made in the upstream Tagger extension previously.  If you have improvements that can go upstream, we can avoid this duplication of changes. 
